### PR TITLE
ReplyTo is case sensitive in calls to sendinblue

### DIFF
--- a/lib/nodemailer-sendinblue-v3-transport.js
+++ b/lib/nodemailer-sendinblue-v3-transport.js
@@ -52,7 +52,7 @@ function V3() {
       body.to = V3Compliant.addresses(data.to);
       body.cc = V3Compliant.addresses(data.cc);
       body.bcc = V3Compliant.addresses(data.bcc);
-      body.replyto = V3Compliant.addresses(data.replyTo);
+      body.replyTo = V3Compliant.addresses(data.replyTo);
     }
     return body;
   };
@@ -415,7 +415,7 @@ SendinBlueTransport.prototype.buildBody = function (mail) {
     to: transformAddresses(data.to),
     cc: transformAddresses(data.cc),
     bcc: transformAddresses(data.bcc),
-    replyto: transformFromAddresses(data.replyTo),
+    replyTo: transformFromAddresses(data.replyTo),
     subject: data.subject,
     text: data.text,
     html: data.html,

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -102,7 +102,7 @@ describe('Sendinblue transporter V2 API', function() {
         assert.deepStrictEqual(body.to, { 'example@test.net': '' });
         assert.deepStrictEqual(body.cc, { 'example@test.net': '' });
         assert.deepStrictEqual(body.bcc, { 'example@test.net': '' });
-        assert.deepStrictEqual(body.replyto, ['example@test.net', '']);
+        assert.deepStrictEqual(body.replyTo, ['example@test.net', '']);
         done();
       });
     });
@@ -261,7 +261,7 @@ describe('Sendinblue transporter V3 API', function() {
         assert.deepStrictEqual(body.to, { email: 'example@test.net' });
         assert.deepStrictEqual(body.cc, { email: 'example@test.net' });
         assert.deepStrictEqual(body.bcc, { email: 'example@test.net' });
-        assert.deepStrictEqual(body.replyto, { email: 'example@test.net' });
+        assert.deepStrictEqual(body.replyTo, { email: 'example@test.net' });
         done();
       });
     });


### PR DESCRIPTION
Fixed in our fork but just incase it's useful to merge and update npm, this fixes replyTo functionality which currently silently fails (just falls-back to the from address)